### PR TITLE
upstream changes to abs command.

### DIFF
--- a/bin/kn.d/abs
+++ b/bin/kn.d/abs
@@ -1,5 +1,10 @@
 #!/usr/bin/perl
 use v5.10; use strict; use warnings;
 use File::Spec;
-$ARGV[0] =~ tr,.,/,;
+$ARGV[0] =~ s,^/+,,;
 say File::Spec->join($ENV{'KN'},$ARGV[0])
+
+__END__
+
+`s,^/+,,` ensures `join` doesn't return path containing "//" in place of
+contact of two joined pathes.

--- a/bin/kn.d/abs
+++ b/bin/kn.d/abs
@@ -1,13 +1,13 @@
 #!/usr/bin/perl
 use v5.10; use strict; use warnings;
 use File::Spec;
-$ARGV[0] =~ s,/?\.+/,/,g;
+$ARGV[0] =~ s,/?(\.+/|\.{2\,}),/,g;
 $ARGV[0] =~ s,^/+,,;
 say File::Spec->join($ENV{'KN'},$ARGV[0])
 
 __END__
 
-`s,/?\.+/,/,g` ensures path doesn't contain `..` to escape root $KN path.
+`s,/?(\.+/|\.{2\,}),/,g` ensures path doesn't contain `..` to escape root $KN path.
 
 `s,^/+,,` ensures `join` doesn't return path containing "//" in place of
 contact of two joined pathes.

--- a/bin/kn.d/abs
+++ b/bin/kn.d/abs
@@ -1,10 +1,13 @@
 #!/usr/bin/perl
 use v5.10; use strict; use warnings;
 use File::Spec;
+$ARGV[0] =~ s,/?\.+/,/,g;
 $ARGV[0] =~ s,^/+,,;
 say File::Spec->join($ENV{'KN'},$ARGV[0])
 
 __END__
+
+`s,/?\.+/,/,g` ensures path doesn't contain `..` to escape root $KN path.
 
 `s,^/+,,` ensures `join` doesn't return path containing "//" in place of
 contact of two joined pathes.

--- a/bin/kn.d/abs
+++ b/bin/kn.d/abs
@@ -1,13 +1,16 @@
 #!/usr/bin/perl
 use v5.10; use strict; use warnings;
 use File::Spec;
-$ARGV[0] =~ s,/?(\.+/|\.{2\,}),/,g;
+$ARGV[0] =~ s,\.{2\,},,g;
 $ARGV[0] =~ s,^/+,,;
 say File::Spec->join($ENV{'KN'},$ARGV[0])
 
 __END__
 
-`s,/?(\.+/|\.{2\,}),/,g` ensures path doesn't contain `..` to escape root $KN path.
+`s,\.{2\,},,g` ensures path doesn't contain `..` to escape root $KN path.
 
 `s,^/+,,` ensures `join` doesn't return path containing "//" in place of
 contact of two joined pathes.
+
+Note: order of regx commands above matters, because seconds one cleans up
+after the first.


### PR DESCRIPTION
Hi, I'm not sure why did you apply `tr,.,/,`, but I didn't find it very useful since it breaks file ext, hidden dirs or any dirs and files that contain `.`.
Instead I added a regx expr that beautifies the result to never contain `//` and secures that argument can't escape root $KN path.

Examples:
```
# before (with tr)
>>> kn abs /a/a.md
... /path/to/KN//a/md
# before (without tr)
>>> kn abs /a/a.md
... /path/to/KN//a/a.md
# now
>>> kn abs /a/a.md
... /path/to/KN/a/a.md
# securing path
>>> kn abs ../a/a.md/../../..
... /path/to/KN/a/a.md
```

Please, let me know if I'm missing something.